### PR TITLE
fix(devplugin):  修复 “运行项目” 与 “保存项目” 无反应的 bug

### DIFF
--- a/common/src/main/java/com/stardust/io/Zip.java
+++ b/common/src/main/java/com/stardust/io/Zip.java
@@ -34,9 +34,15 @@ public class Zip {
                 }
             }
         } finally {
-            closeSilently(fos);
-            closeSilently(stream);
-            closeSilently(zis);
+            if (fos != null) {
+                closeSilently(fos);
+            }
+            if (stream != null) {
+                closeSilently(stream);
+            }
+            if (zis != null) {
+                closeSilently(zis);
+            }
         }
     }
 


### PR DESCRIPTION
在 finally 中 fos 变量已经是 null ，
传入 closeSilently 方法后会被 kotlin 的 非空检测 抛出 空指针异常，

所以在调用的时候判断 !=null ，
为 null 时不再调用 closeSilently 。

Fix https://github.com/kkevsekk1/AutoX/issues/399