### PR TITLE
让控制台打印Error的方式更友好

### DIFF
--- a/autojs/src/main/assets/modules/__util__.js
+++ b/autojs/src/main/assets/modules/__util__.js
@@ -372,7 +372,7 @@ function formatJavaArray(javaArray){
 }
 
 function formatError(value) {
-  return '[' + Error.prototype.toString.call(value) + ']';
+  return [Error.prototype.toString.call(value), value.stack].filter(Boolean).join('\n');
 }
 
 


### PR DESCRIPTION
将console打印Error对象时的行为，调整为与Chrome和Node.js等平台保持一致，打印堆栈信息。
