### PR TITLE
设置默认日志文件

### DIFF
--- a/autojs/src/main/assets/modules/__console__.js
+++ b/autojs/src/main/assets/modules/__console__.js
@@ -95,5 +95,9 @@ module.exports = function (runtime, scope) {
     scope.openConsole = console.show.bind(console);
     scope.clearConsole = console.clear.bind(console);
 
+    console.setGlobalLogConfig({
+        file: files.join(context.getExternalFilesDir("logs"), "log.txt")
+    });
+
     return console;
 }


### PR DESCRIPTION
我在受到 #457 的启发，给本项目开发远程调试工具时，发现 autojs pro 默认是打开了日志文件输出的，可以很方便的使用adb命令来替代vs code插件，在PC端查看日志：
```bash
adb shell tail -f /storage/emulated/0/Android/data/org.autojs.autojspro/files/logs/log.txt
```
我在开发中，js的报错尝尝引发AutoX APP的崩溃，这时vs code就会断开连接，屏幕上的日志也会清空，需要手工打开日志界面查看崩溃前的日志，还需要重新打开APP并重连vscode，这样的使用体验十分恼人。这个PR将解决部分问题。

PS：剩下的问题我已通过重新编写的webpack插件解决，不再依赖vscode插件和AutoX的ws通信通道，改用adb来实现文件上传、远程运行（感谢@James4Ever0 的启发）。目前正在自测、编写文档。