### PR TITLE
调整崩溃日志界面

### DIFF
--- a/app/src/main/java/org/autojs/autojs/ui/error/ErrorReportActivity.java
+++ b/app/src/main/java/org/autojs/autojs/ui/error/ErrorReportActivity.java
@@ -2,33 +2,40 @@ package org.autojs.autojs.ui.error;
 
 import android.content.ClipData;
 import android.content.ClipboardManager;
-import android.os.Build;
+import android.content.Context;
+import android.content.Intent;
 import android.os.Bundle;
-import android.preference.PreferenceManager;
-
-import androidx.appcompat.widget.Toolbar;
 import android.util.Log;
 import android.util.SparseIntArray;
+import android.view.View;
+import android.widget.Button;
+import android.widget.TextView;
 import android.widget.Toast;
 
-import org.autojs.autoxjs.BuildConfig;
+import androidx.appcompat.widget.Toolbar;
+
+import com.heinrichreimersoftware.androidissuereporter.model.DeviceInfo;
+
 import org.autojs.autojs.ui.BaseActivity;
-import org.autojs.autojs.theme.dialog.ThemeColorMaterialDialogBuilder;
+import org.autojs.autojs.ui.main.MainActivity;
 import org.autojs.autoxjs.R;
 
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.Locale;
-import java.util.Timer;
-import java.util.TimerTask;
+import java.util.Objects;
 
 /**
  * Created by Stardust on 2017/2/2.
  */
-
 public class ErrorReportActivity extends BaseActivity {
 
     private static final String TAG = "ErrorReportActivity";
     private static final SparseIntArray CRASH_COUNT = new SparseIntArray();
-    private static final String KEY_CRASH_COUNT = "crashCount";
+    private static final String KEY_CRASH_COUNT = "crash_count";
 
     static {
         CRASH_COUNT.put(2, R.string.text_again);
@@ -37,85 +44,70 @@ public class ErrorReportActivity extends BaseActivity {
         CRASH_COUNT.put(5, R.string.text_again_and_again_again_again);
     }
 
-    private String mTitle;
-
     protected void onCreate(Bundle savedInstanceState) {
         try {
             super.onCreate(savedInstanceState);
-            mTitle = getCrashCountText() + getString(R.string.text_crash);
-            setUpUI();
-            handleIntent();
+            setContentView(R.layout.activity_error_report);
         } catch (Throwable throwable) {
             Log.e(TAG, "", throwable);
             exit();
         }
+    }
 
+    protected void onStart() {
+        super.onStart();
+        setUpUI();
+        handleIntent();
     }
 
     private String getCrashCountText() {
-        int i = PreferenceManager.getDefaultSharedPreferences(this).getInt(KEY_CRASH_COUNT, 0);
-        i++;
-        PreferenceManager.getDefaultSharedPreferences(this).edit().putInt(KEY_CRASH_COUNT, i).apply();
-        if (i < 2)
-            return "";
-        if (i > 5)
-            i = 5;
-        return getString(CRASH_COUNT.get(i));
+        int i = getPreferences(Context.MODE_PRIVATE).getInt(KEY_CRASH_COUNT, 0) + 1;
+        getPreferences(Context.MODE_PRIVATE).edit().putInt(KEY_CRASH_COUNT, i).apply();
+        if (i < 2) return "";
+        return getString(CRASH_COUNT.get(Math.min(i, 5)));
     }
-
 
     private void handleIntent() {
         String message = getIntent().getStringExtra("message");
-        final String errorDetail = getIntent().getStringExtra("error");
-        showErrorMessageByDialog(message, errorDetail);
-        //showErrorMessage(message, errorDetail);
-    }
-
-    private void showErrorMessageByDialog(String message, final String errorDetail) {
-        new ThemeColorMaterialDialogBuilder(this)
-                .title(mTitle)
-                .content(R.string.crash_feedback)
-                .positiveText(R.string.text_exit)
-                .negativeText(R.string.text_copy_debug_info)
-                .onPositive((dialog, which) -> exit())
-                .onNegative((dialog, which) -> {
-                    copyToClip(getDeviceMessage() + message + "\n" + errorDetail);
-                    exitAfter(1000);
-                })
-                .cancelable(false)
-                .show();
+        String errorDetail = getIntent().getStringExtra("error");
+        TextView errorTextView = $(R.id.error);
+        if (errorTextView != null) {
+            String crashInfo = String.format("%s错误信息:\n%s\n%s", getDeviceMessage(), message, errorDetail);
+            errorTextView.setText(crashInfo);
+            saveCrashLog(crashInfo);
+        }
     }
 
     private String getDeviceMessage() {
-        return String.format(Locale.getDefault(), "Version: %s\nAndroid: %d\n", BuildConfig.VERSION_CODE, Build.VERSION.SDK_INT);
-    }
-
-    private void exitAfter(long millis) {
-        new Timer().schedule(new TimerTask() {
-            @Override
-            public void run() {
-                exit();
-            }
-        }, millis);
+        DeviceInfo deviceInfo = new DeviceInfo(this);
+        return String.format(Locale.getDefault(), "设备信息: \n%s\n\n", deviceInfo);
     }
 
     private void copyToClip(String text) {
-        ((ClipboardManager) getSystemService(CLIPBOARD_SERVICE))
-                .setPrimaryClip(ClipData.newPlainText("Debug", text));
-        Toast.makeText(ErrorReportActivity.this, R.string.text_already_copy_to_clip, Toast.LENGTH_SHORT).show();
+        ClipboardManager clipboard = (ClipboardManager) getSystemService(Context.CLIPBOARD_SERVICE);
+        ClipData clip = ClipData.newPlainText("Debug", text);
+        if (clipboard != null) {
+            clipboard.setPrimaryClip(clip);
+            Toast.makeText(ErrorReportActivity.this, R.string.text_already_copy_to_clip, Toast.LENGTH_SHORT).show();
+        }
     }
 
     private void setUpUI() {
-        setContentView(R.layout.activity_error_report);
-        setUpToolbar();
-    }
+        Toolbar toolbar = $(R.id.toolbar);
+        Button copyButton = $(R.id.copy);
+        Button restartButton = $(R.id.restart);
+        Button exitButton = $(R.id.exit);
 
-    private void setUpToolbar() {
-        Toolbar toolbar;
-        toolbar = (Toolbar) findViewById(R.id.toolbar);
-        toolbar.setTitle(getString(R.string.text_error_report));
+        String mTitle = String.format("%s%s", getCrashCountText(), getString(R.string.text_crash));
+        toolbar.setTitle(mTitle);
         setSupportActionBar(toolbar);
-        getSupportActionBar().setHomeButtonEnabled(false);
+        Objects.requireNonNull(getSupportActionBar()).setHomeButtonEnabled(false);
+
+        copyButton.setOnClickListener(this::copy);
+
+        restartButton.setOnClickListener(this::restar);
+
+        exitButton.setOnClickListener(view -> exit());
     }
 
     @Override
@@ -127,6 +119,40 @@ public class ErrorReportActivity extends BaseActivity {
         finishAffinity();
     }
 
+    private void saveCrashLog(String crashInfo) {
+        try {
+            File logDir = new File(getExternalFilesDir(null), "AutoJs_Log");
+            if (!logDir.exists() && !logDir.mkdirs()) {
+                Log.e(TAG, "Error creating directory: " + logDir.getAbsolutePath());
+            }
+            String timeStamp = new SimpleDateFormat("yyyyMMdd_HHmmss", Locale.getDefault()).format(new Date());
+            String fileName = "Log_" + timeStamp + ".txt";
+            File logFile = new File(logDir, fileName);
+            try (FileWriter writer = new FileWriter(logFile)) {
+                writer.write(crashInfo);
+            }
+            TextView saveTextView = $(R.id.save_path);
+            if (saveTextView != null) {
+                String savedToText = getString(R.string.text_error_save, logFile.getAbsolutePath());
+                saveTextView.setText(savedToText);
+            }
+        } catch (IOException e) {
+            Log.e(TAG, "Error saving crash log", e);
+        }
+    }
+
+    private void copy(View view) {
+        TextView errorTextView = $(R.id.error);
+        if (errorTextView != null) {
+            String crashInfo = errorTextView.getText().toString();
+            copyToClip(crashInfo);
+        }
+    }
+
+    private void restar(View view) {
+        Intent intent = new Intent(this, MainActivity.class);
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
+        startActivity(intent);
+        finish();
+    }
 }
-
-

--- a/app/src/main/java/org/autojs/autojs/ui/settings/AboutActivity.java
+++ b/app/src/main/java/org/autojs/autojs/ui/settings/AboutActivity.java
@@ -5,23 +5,20 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import com.afollestad.materialdialogs.MaterialDialog;
-
-import org.autojs.autojs.tool.IntentTool;
-import org.autojs.autojs.ui.BaseActivity;
-import org.autojs.autojs.theme.dialog.ThemeColorMaterialDialogBuilder;
-
 import com.stardust.util.ClipboardUtil;
 import com.stardust.util.IntentUtil;
 import com.stardust.util.IntentUtilKt;
 import com.tencent.bugly.crashreport.CrashReport;
 
-import org.autojs.autoxjs.BuildConfig;
-import org.autojs.autoxjs.R;
-
 import org.androidannotations.annotations.AfterViews;
 import org.androidannotations.annotations.Click;
 import org.androidannotations.annotations.EActivity;
 import org.androidannotations.annotations.ViewById;
+import org.autojs.autojs.theme.dialog.ThemeColorMaterialDialogBuilder;
+import org.autojs.autojs.tool.IntentTool;
+import org.autojs.autojs.ui.BaseActivity;
+import org.autojs.autoxjs.BuildConfig;
+import org.autojs.autoxjs.R;
 
 /**
  * Created by Stardust on 2017/2/2.
@@ -76,32 +73,23 @@ public class AboutActivity extends BaseActivity {
     @Click(R.id.icon)
     void lol() {
         mLolClickCount++;
-//        Toast.makeText(this, R.string.text_lll, Toast.LENGTH_LONG).show();
         if (mLolClickCount >= 5) {
+            mLolClickCount = 0;
             crashTest();
-            showEasterEgg();
         }
     }
 
     private void showEasterEgg() {
-        new MaterialDialog.Builder(this)
-                .customView(R.layout.paint_layout, false)
-                .show();
+        new MaterialDialog.Builder(this).customView(R.layout.paint_layout, false).show();
     }
 
     private void crashTest() {
-        new ThemeColorMaterialDialogBuilder(this)
-                .title("Crash Test")
-                .positiveText("Crash")
-                .onPositive((dialog, which) -> {
-                    CrashReport.testJavaCrash();
-                }).show();
+        new ThemeColorMaterialDialogBuilder(this).title("Crash Test").positiveText("Crash").onPositive((dialog, which) -> CrashReport.testJavaCrash()).show();
     }
 
     @Click(R.id.developer)
     void hhh() {
         Toast.makeText(this, R.string.text_it_is_the_developer_of_app, Toast.LENGTH_LONG).show();
     }
-
 
 }

--- a/app/src/main/res-i18n/values/strings.xml
+++ b/app/src/main/res-i18n/values/strings.xml
@@ -1,4 +1,9 @@
 <resources>
+    <string name="text_error_copy">复制信息</string>
+    <string name="text_error_restart">重启软件</string>
+    <string name="text_error_exit">退出软件</string>
+    <string name="text_error_save">已保存到路径:%1$s</string>
+
     <string name="app_name" translatable="false">Autox.js</string>
     <string name="text_broadcast_action_prefix" translatable="false">android.intent.action.</string>
     <string name="text_en_import" translatable="false">import</string>

--- a/app/src/main/res/layout/activity_error_report.xml
+++ b/app/src/main/res/layout/activity_error_report.xml
@@ -1,34 +1,92 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              xmlns:app="http://schemas.android.com/apk/res-auto"
-              xmlns:tools="http://schemas.android.com/tools"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent"
-              android:orientation="vertical">
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
     <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appBarLayout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:theme="@style/AppTheme.AppBarOverlay">
 
         <com.stardust.theme.widget.ThemeColorToolbar
             android:id="@+id/toolbar"
-            android:theme="@style/ToolBarStyle"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
             android:background="?attr/colorPrimary"
+            android:theme="@style/ToolBarStyle"
             app:popupTheme="@style/AppTheme.PopupOverlay">
 
         </com.stardust.theme.widget.ThemeColorToolbar>
     </com.google.android.material.appbar.AppBarLayout>
 
-    <TextView
-        android:id="@+id/error"
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:padding="16dp"
-        android:scrollbars="vertical"
-        android:textColor="@android:color/secondary_text_light"
-        android:textSize="16sp"
-        tools:text="错误"/>
-</LinearLayout>
+        android:layout_above="@+id/buttonsLayout"
+        android:layout_below="@id/appBarLayout"
+        android:orientation="vertical">
+
+        <ScrollView
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1">
+
+            <TextView
+                android:id="@+id/error"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:padding="16dp"
+                android:scrollbars="vertical"
+                android:textColor="#333333"
+                android:textSize="16sp" />
+
+        </ScrollView>
+
+        <TextView
+            android:id="@+id/save_path"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:padding="16dp"
+            android:textColor="#333333"
+            android:textSize="16sp" />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/buttonsLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:orientation="horizontal">
+
+        <Button
+            android:id="@+id/copy"
+            style="?android:attr/borderlessButtonStyle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/text_error_copy" />
+
+        <Button
+            android:id="@+id/restart"
+            style="?android:attr/borderlessButtonStyle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/text_error_restart" />
+
+        <Button
+            android:id="@+id/exit"
+            style="?android:attr/borderlessButtonStyle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/text_error_exit" />
+
+    </LinearLayout>
+
+</RelativeLayout>


### PR DESCRIPTION
1.调整崩溃日志界面，日志保存到AutoJs_Log目录

<img width="538" alt="screenshot" src="https://github.com/kkevsekk1/AutoX/assets/106499400/0c159a90-61bc-4e30-b2ba-c2fddca08124">

2.去掉点击图标出现的无意义布局


有一个问题，崩溃后有几率不触发该界面，日志保存不到。
日志管理尚未实现，需要自行处理