### PR TITLE
调整主页搜索和旧编辑器

### DIFF
--- a/app/src/main/assets/js/js-beautify/beautify.js
+++ b/app/src/main/assets/js/js-beautify/beautify.js
@@ -2846,7 +2846,8 @@ if (typeof define === "function" && define.amd) {
 function beautify(source){
     return js_beautify(source, {
            'indent_size': 4,
-           'e4x': true
+           'e4x': true,
+           max_preserve_newlines:2
     });
 }
 

--- a/app/src/main/java/org/autojs/autojs/Pref.java
+++ b/app/src/main/java/org/autojs/autojs/Pref.java
@@ -10,6 +10,7 @@ import com.stardust.autojs.runtime.accessibility.AccessibilityConfig;
 
 import org.autojs.autojs.autojs.key.GlobalKeyObserver;
 import org.autojs.autoxjs.R;
+
 import java.io.File;
 import java.util.concurrent.TimeUnit;
 
@@ -24,6 +25,15 @@ public class Pref {
     private static final String KEY_FLOATING_MENU_SHOWN = "KEY_FLOATING_MENU_SHOWN";
     private static final String KEY_EDITOR_THEME = "editor.theme";
     private static final String KEY_EDITOR_TEXT_SIZE = "editor.textSize";
+    private static final String KEY_EDITOR_NEW = "KEY_EDITOR_NEW";
+
+    public static boolean getEditor() {
+        return def().getBoolean(KEY_EDITOR_NEW, true);
+    }
+
+    public static void setEditor(boolean shouldOpen) {
+        def().edit().putBoolean(KEY_EDITOR_NEW, shouldOpen).apply();
+    }
 
     private static SharedPreferences.OnSharedPreferenceChangeListener onSharedPreferenceChangeListener = new SharedPreferences.OnSharedPreferenceChangeListener() {
         @Override

--- a/app/src/main/java/org/autojs/autojs/model/script/Scripts.kt
+++ b/app/src/main/java/org/autojs/autojs/model/script/Scripts.kt
@@ -3,9 +3,8 @@ package org.autojs.autojs.model.script
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
-import androidx.annotation.Nullable
 import android.widget.Toast
-
+import androidx.annotation.Nullable
 import com.stardust.app.GlobalAppContext
 import com.stardust.autojs.execution.ExecutionConfig
 import com.stardust.autojs.execution.ScriptExecution
@@ -13,18 +12,15 @@ import com.stardust.autojs.execution.SimpleScriptExecutionListener
 import com.stardust.autojs.runtime.exception.ScriptInterruptedException
 import com.stardust.autojs.script.ScriptSource
 import com.stardust.util.IntentUtil
-
 import org.autojs.autojs.Pref
-import org.autojs.autoxjs.R
 import org.autojs.autojs.autojs.AutoJs
 import org.autojs.autojs.external.ScriptIntents
 import org.autojs.autojs.external.fileprovider.AppFileProvider
 import org.autojs.autojs.external.shortcut.Shortcut
 import org.autojs.autojs.external.shortcut.ShortcutActivity
 import org.autojs.autojs.ui.edit.EditActivity
-
+import org.autojs.autoxjs.R
 import org.mozilla.javascript.RhinoException
-
 import java.io.File
 import java.io.FileFilter
 
@@ -91,7 +87,7 @@ object Scripts {
 
 
     fun edit(context: Context, file: ScriptFile) {
-        EditActivity.editFile(context, file.simplifiedName, file.path, true)
+        EditActivity.editFile(context, file.simplifiedName, file.path, false)
     }
 
     fun edit(context: Context, path: String) {

--- a/app/src/main/java/org/autojs/autojs/model/script/Scripts.kt
+++ b/app/src/main/java/org/autojs/autojs/model/script/Scripts.kt
@@ -3,6 +3,7 @@ package org.autojs.autojs.model.script
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
 import android.widget.Toast
 import androidx.annotation.Nullable
 import com.stardust.app.GlobalAppContext
@@ -18,11 +19,12 @@ import org.autojs.autojs.external.ScriptIntents
 import org.autojs.autojs.external.fileprovider.AppFileProvider
 import org.autojs.autojs.external.shortcut.Shortcut
 import org.autojs.autojs.external.shortcut.ShortcutActivity
-import org.autojs.autojs.ui.edit.EditActivity
 import org.autojs.autoxjs.R
 import org.mozilla.javascript.RhinoException
 import java.io.File
 import java.io.FileFilter
+import com.aiselp.autojs.codeeditor.EditActivity as EditActivity2
+import org.autojs.autojs.ui.edit.EditActivity as EditActivity1
 
 /**
  * Created by Stardust on 2017/5/3.
@@ -40,33 +42,38 @@ object Scripts {
                 || file.name.endsWith(".auto")
     }
 
-    private val BROADCAST_SENDER_SCRIPT_EXECUTION_LISTENER = object : SimpleScriptExecutionListener() {
+    private val BROADCAST_SENDER_SCRIPT_EXECUTION_LISTENER =
+        object : SimpleScriptExecutionListener() {
 
-        override fun onSuccess(execution: ScriptExecution, result: Any?) {
-            GlobalAppContext.get().sendBroadcast(Intent(ACTION_ON_EXECUTION_FINISHED))
-        }
-
-        override fun onException(execution: ScriptExecution, e: Throwable) {
-            val rhinoException = getRhinoException(e)
-            var line = -1
-            var col = 0
-            if (rhinoException != null) {
-                line = rhinoException.lineNumber()
-                col = rhinoException.columnNumber()
+            override fun onSuccess(execution: ScriptExecution, result: Any?) {
+                GlobalAppContext.get().sendBroadcast(Intent(ACTION_ON_EXECUTION_FINISHED))
             }
-            if (ScriptInterruptedException.causedByInterrupted(e)) {
-                GlobalAppContext.get().sendBroadcast(Intent(ACTION_ON_EXECUTION_FINISHED)
-                        .putExtra(EXTRA_EXCEPTION_LINE_NUMBER, line)
-                        .putExtra(EXTRA_EXCEPTION_COLUMN_NUMBER, col))
-            } else {
-                GlobalAppContext.get().sendBroadcast(Intent(ACTION_ON_EXECUTION_FINISHED)
-                        .putExtra(EXTRA_EXCEPTION_MESSAGE, e.message)
-                        .putExtra(EXTRA_EXCEPTION_LINE_NUMBER, line)
-                        .putExtra(EXTRA_EXCEPTION_COLUMN_NUMBER, col))
-            }
-        }
 
-    }
+            override fun onException(execution: ScriptExecution, e: Throwable) {
+                val rhinoException = getRhinoException(e)
+                var line = -1
+                var col = 0
+                if (rhinoException != null) {
+                    line = rhinoException.lineNumber()
+                    col = rhinoException.columnNumber()
+                }
+                if (ScriptInterruptedException.causedByInterrupted(e)) {
+                    GlobalAppContext.get().sendBroadcast(
+                        Intent(ACTION_ON_EXECUTION_FINISHED)
+                            .putExtra(EXTRA_EXCEPTION_LINE_NUMBER, line)
+                            .putExtra(EXTRA_EXCEPTION_COLUMN_NUMBER, col)
+                    )
+                } else {
+                    GlobalAppContext.get().sendBroadcast(
+                        Intent(ACTION_ON_EXECUTION_FINISHED)
+                            .putExtra(EXTRA_EXCEPTION_MESSAGE, e.message)
+                            .putExtra(EXTRA_EXCEPTION_LINE_NUMBER, line)
+                            .putExtra(EXTRA_EXCEPTION_COLUMN_NUMBER, col)
+                    )
+                }
+            }
+
+        }
 
 
     fun openByOtherApps(uri: Uri) {
@@ -79,15 +86,19 @@ object Scripts {
 
     fun createShortcut(scriptFile: ScriptFile) {
         Shortcut(GlobalAppContext.get()).name(scriptFile.simplifiedName)
-                .targetClass(ShortcutActivity::class.java)
-                .iconRes(R.drawable.ic_node_js_black)
-                .extras(Intent().putExtra(ScriptIntents.EXTRA_KEY_PATH, scriptFile.path))
-                .send()
+            .targetClass(ShortcutActivity::class.java)
+            .iconRes(R.drawable.ic_node_js_black)
+            .extras(Intent().putExtra(ScriptIntents.EXTRA_KEY_PATH, scriptFile.path))
+            .send()
     }
 
 
     fun edit(context: Context, file: ScriptFile) {
-        EditActivity.editFile(context, file.simplifiedName, file.path, false)
+        if (Pref.getEditor() && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            EditActivity2.editFile(context, file)
+        } else {
+            EditActivity1.editFile(context, file.simplifiedName, file.path, false)
+        }
     }
 
     fun edit(context: Context, path: String) {
@@ -96,8 +107,10 @@ object Scripts {
 
     fun run(file: ScriptFile): ScriptExecution? {
         return try {
-            AutoJs.getInstance().scriptEngineService.execute(file.toSource(),
-                    ExecutionConfig(workingDirectory = file.parent))
+            AutoJs.getInstance().scriptEngineService.execute(
+                file.toSource(),
+                ExecutionConfig(workingDirectory = file.parent)
+            )
         } catch (e: Exception) {
             e.printStackTrace()
             Toast.makeText(GlobalAppContext.get(), e.message, Toast.LENGTH_LONG).show()
@@ -109,7 +122,10 @@ object Scripts {
 
     fun run(source: ScriptSource): ScriptExecution? {
         return try {
-            AutoJs.getInstance().scriptEngineService.execute(source, ExecutionConfig(workingDirectory = Pref.getScriptDirPath()))
+            AutoJs.getInstance().scriptEngineService.execute(
+                source,
+                ExecutionConfig(workingDirectory = Pref.getScriptDirPath())
+            )
         } catch (e: Exception) {
             e.printStackTrace()
             Toast.makeText(GlobalAppContext.get(), e.message, Toast.LENGTH_LONG).show()
@@ -119,16 +135,27 @@ object Scripts {
     }
 
     fun runWithBroadcastSender(file: File): ScriptExecution {
-        return AutoJs.getInstance().scriptEngineService.execute(ScriptFile(file).toSource(), BROADCAST_SENDER_SCRIPT_EXECUTION_LISTENER,
-                ExecutionConfig(workingDirectory = file.parent))
+        return AutoJs.getInstance().scriptEngineService.execute(
+            ScriptFile(file).toSource(), BROADCAST_SENDER_SCRIPT_EXECUTION_LISTENER,
+            ExecutionConfig(workingDirectory = file.parent)
+        )
     }
 
 
-    fun runRepeatedly(scriptFile: ScriptFile, loopTimes: Int, delay: Long, interval: Long): ScriptExecution {
+    fun runRepeatedly(
+        scriptFile: ScriptFile,
+        loopTimes: Int,
+        delay: Long,
+        interval: Long
+    ): ScriptExecution {
         val source = scriptFile.toSource()
         val directoryPath = scriptFile.parent
-        return AutoJs.getInstance().scriptEngineService.execute(source, ExecutionConfig(workingDirectory = directoryPath,
-                delay = delay, loopTimes = loopTimes, interval = interval))
+        return AutoJs.getInstance().scriptEngineService.execute(
+            source, ExecutionConfig(
+                workingDirectory = directoryPath,
+                delay = delay, loopTimes = loopTimes, interval = interval
+            )
+        )
     }
 
     @Nullable
@@ -145,11 +172,17 @@ object Scripts {
 
     fun send(file: ScriptFile) {
         val context = GlobalAppContext.get()
-        context.startActivity(Intent.createChooser(Intent(Intent.ACTION_SEND)
-                .setType("text/plain")
-                .putExtra(Intent.EXTRA_STREAM, IntentUtil.getUriOfFile(context, file.path, AppFileProvider.AUTHORITY)),
+        context.startActivity(
+            Intent.createChooser(
+                Intent(Intent.ACTION_SEND)
+                    .setType("text/plain")
+                    .putExtra(
+                        Intent.EXTRA_STREAM,
+                        IntentUtil.getUriOfFile(context, file.path, AppFileProvider.AUTHORITY)
+                    ),
                 GlobalAppContext.getString(R.string.text_send)
-        ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+            ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        )
 
     }
 }

--- a/app/src/main/java/org/autojs/autojs/ui/main/MainActivity.kt
+++ b/app/src/main/java/org/autojs/autojs/ui/main/MainActivity.kt
@@ -354,14 +354,19 @@ private fun TopBar(
                         )
                     }
                 }
-                IconButton(onClick = { isSearch = true }) {
-                    Icon(
-                        imageVector = Icons.Default.Search,
-                        contentDescription = stringResource(id = R.string.text_search)
-                    )
+                if (currentPage == 0) {
+                    IconButton(onClick = { isSearch = true }) {
+                        Icon(
+                            imageVector = Icons.Default.Search,
+                            contentDescription = stringResource(id = R.string.text_search)
+                        )
+                    }
                 }
             } else {
-                IconButton(onClick = { isSearch = false }) {
+                IconButton(onClick = {
+                    isSearch = false
+                    onSearch("")
+                }) {
                     Icon(
                         imageVector = Icons.Default.ArrowBack,
                         contentDescription = stringResource(id = R.string.text_exit_search)
@@ -380,6 +385,14 @@ private fun TopBar(
                         onSearch(keyword)
                     })
                 )
+                if (keyword.isNotEmpty()) {
+                    IconButton(onClick = { keyword = "" }) {
+                        Icon(
+                            imageVector = Icons.Default.Clear,
+                            contentDescription = null
+                        )
+                    }
+                }
             }
             LogButton()
             when (currentPage) {

--- a/app/src/main/java/org/autojs/autojs/ui/main/drawer/DrawerPage.kt
+++ b/app/src/main/java/org/autojs/autojs/ui/main/drawer/DrawerPage.kt
@@ -7,7 +7,6 @@ import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.provider.Settings
-import android.util.Log
 import android.widget.TextView
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
@@ -17,6 +16,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.ExitToApp
 import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.Settings
@@ -787,7 +787,21 @@ private fun AccessibilityServiceSwitch() {
                 ).show()
             }
         }
-
+    var editor by remember { mutableStateOf(Pref.getEditor()) }
+    SwitchItem(
+        icon = {
+            MyIcon(
+                Icons.Default.Edit,
+                contentDescription = null,
+            )
+        },
+        text = { Text(text = "启用新编辑器") },
+        checked = editor,
+        onCheckedChange = { isChecked ->
+            editor = isChecked
+            Pref.setEditor(isChecked)
+        }
+    )
     SwitchItem(
         icon = {
             MyIcon(

--- a/app/src/main/java/org/autojs/autojs/ui/main/scripts/ScriptListFragment.kt
+++ b/app/src/main/java/org/autojs/autojs/ui/main/scripts/ScriptListFragment.kt
@@ -1,7 +1,6 @@
 package org.autojs.autojs.ui.main.scripts
 
 import android.content.Context
-import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -26,7 +25,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.fragment.app.Fragment
 import androidx.preference.PreferenceManager
-import com.aiselp.autojs.codeeditor.EditActivity
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.leinardi.android.speeddial.compose.FabWithLabel
 import com.leinardi.android.speeddial.compose.SpeedDial
@@ -48,7 +46,6 @@ import org.autojs.autojs.ui.main.showExternalStoragePermissionToast
 import org.autojs.autojs.ui.viewmodel.ExplorerItemList.SortConfig
 import org.autojs.autojs.ui.widget.fillMaxSize
 import org.autojs.autoxjs.R
-import java.io.File
 
 /**
  * Created by wilinz on 2022/7/15.
@@ -240,9 +237,7 @@ class ScriptListFragment : Fragment() {
         setOnItemClickListener { _, item ->
             item?.let {
                 if (item.isEditable) {
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                        EditActivity.editFile(requireContext(), File(item.path))
-                    } else edit(requireContext(), item.toScriptFile())
+                    edit(requireContext(), item.toScriptFile());
                 } else {
                     IntentUtil.viewFile(get(), item.path, AppFileProvider.AUTHORITY)
                 }


### PR DESCRIPTION
旧编辑器调整：
1.进入编辑器不会启用新后台  #738
2.修复编辑器显示不是所选脚本 #480

 主页搜索框调整
1.搜索图标只在主页出现
2.修复退出搜索没有恢复原始列表
3.添加清除文本按钮

侧边栏添加切换编辑器开关