### PR TITLE
optimize: 优化小米手机使用非小米系统判断后台弹出界面权限的问题

### DIFF
--- a/common/src/main/java/com/stardust/app/permission/BackgroundStartPermission.kt
+++ b/common/src/main/java/com/stardust/app/permission/BackgroundStartPermission.kt
@@ -5,6 +5,9 @@ import android.content.Context
 import android.net.Uri
 import android.os.Build
 import android.provider.Settings
+import java.io.BufferedReader
+import java.io.IOException
+import java.io.InputStreamReader
 
 /**
  * @author wilinz
@@ -14,6 +17,16 @@ object BackgroundStartPermission {
 
     private fun isXiaoMi(): Boolean {
         return checkManufacturer("xiaomi")
+    }
+
+    /**
+    * @author plus1998
+    * @date 2024/4/18
+    * @desc 澎湃OS目前是兼容的
+    */
+    private fun isMiui(): Boolean {
+        val value = getSystemProperty("ro.miui.ui.version.name")
+        return !android.text.TextUtils.isEmpty(value)
     }
 
     private fun isOppo(): Boolean {
@@ -28,17 +41,42 @@ object BackgroundStartPermission {
         return manufacturer.equals(Build.MANUFACTURER, true)
     }
 
+    private fun getSystemProperty(propName: String): String? {
+        val line: String
+        var input: BufferedReader? = null
+        try {
+            val p = Runtime.getRuntime().exec("getprop $propName")
+            input = BufferedReader(InputStreamReader(p.inputStream), 1024)
+            line = input.readLine()
+            input.close()
+        } catch (ex: IOException) {
+            return null
+        } finally {
+            if (input != null) {
+                try {
+                    input.close()
+                } catch (e: IOException) {
+                    // ignore
+                }
+            }
+        }
+        return line
+    }
+
     fun isBackgroundStartAllowed(context: Context): Boolean {
         return when {
-            isXiaoMi() -> {
+            isXiaoMi() && isMiui() -> {
                 isXiaomiBgStartPermissionAllowed(context)
             }
+
             isVivo() -> {
                 isVivoBgStartPermissionAllowed(context)
             }
+
             isOppo() && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M -> {
                 Settings.canDrawOverlays(context)
             }
+
             else -> true
         }
     }


### PR DESCRIPTION
新增了 isMiui() 函数用于优化当 小米手机 使用 “第三方系统” 时判断“后台弹出界面权限的问题”。
经测试，目前在小米14上的Hyper OS也是兼容的