### PR TITLE
Fix register receiver error when launching on Android 14.

### DIFF
--- a/app/src/main/java/org/autojs/autojs/external/receiver/DynamicBroadcastReceivers.java
+++ b/app/src/main/java/org/autojs/autojs/external/receiver/DynamicBroadcastReceivers.java
@@ -36,7 +36,7 @@ public class DynamicBroadcastReceivers {
             mContext.registerReceiver(mDefaultActionReceiver, createIntentFilter(StaticBroadcastReceiver.ACTIONS));
             IntentFilter filter = createIntentFilter(StaticBroadcastReceiver.PACKAGE_ACTIONS);
             filter.addDataScheme("package");
-            mContext.registerReceiver(mPackageActionReceiver, filter);
+            mContext.registerReceiver(mPackageActionReceiver, filter,RECEIVER_EXPORTED);
         }
     }
 
@@ -126,9 +126,9 @@ public class DynamicBroadcastReceivers {
             IntentFilter intentFilter = createIntentFilter(actions);
             if (local) {
                 LocalBroadcastManager broadcastManager = LocalBroadcastManager.getInstance(mContext);
-                broadcastManager.registerReceiver(receiver, intentFilter);
+                broadcastManager.registerReceiver(receiver, intentFilter,RECEIVER_EXPORTED);
             } else {
-                mContext.registerReceiver(receiver, intentFilter);
+                mContext.registerReceiver(receiver, intentFilter,RECEIVER_EXPORTED);
             }
             Log.d(LOG_TAG, "register: " + actions);
             return true;

--- a/app/src/main/java/org/autojs/autojs/external/receiver/DynamicBroadcastReceivers.java
+++ b/app/src/main/java/org/autojs/autojs/external/receiver/DynamicBroadcastReceivers.java
@@ -33,10 +33,10 @@ public class DynamicBroadcastReceivers {
     public DynamicBroadcastReceivers(Context context) {
         mContext = context;
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            mContext.registerReceiver(mDefaultActionReceiver, createIntentFilter(StaticBroadcastReceiver.ACTIONS));
+            compatRegisterReceiver(mContext, mDefaultActionReceiver, createIntentFilter(StaticBroadcastReceiver.ACTIONS), false);
             IntentFilter filter = createIntentFilter(StaticBroadcastReceiver.PACKAGE_ACTIONS);
             filter.addDataScheme("package");
-            mContext.registerReceiver(mPackageActionReceiver, filter,RECEIVER_EXPORTED);
+            compatRegisterReceiver(mContext, mPackageActionReceiver, filter, false);
         }
     }
 
@@ -126,12 +126,25 @@ public class DynamicBroadcastReceivers {
             IntentFilter intentFilter = createIntentFilter(actions);
             if (local) {
                 LocalBroadcastManager broadcastManager = LocalBroadcastManager.getInstance(mContext);
-                broadcastManager.registerReceiver(receiver, intentFilter,RECEIVER_EXPORTED);
+                broadcastManager.registerReceiver(receiver, intentFilter);
             } else {
-                mContext.registerReceiver(receiver, intentFilter,RECEIVER_EXPORTED);
+                compatRegisterReceiver(mContext, receiver, intentFilter, false);
             }
             Log.d(LOG_TAG, "register: " + actions);
             return true;
+        }
+    }
+
+    /**
+     * 参考
+     * <p>https://github.com/facebook/react-native/issues/37769
+     * <p>https://github.com/facebook/react-native/pull/38256/files
+     */
+    private void compatRegisterReceiver(Context context, BroadcastReceiver receiver, IntentFilter filter, boolean exported) {
+        if (Build.VERSION.SDK_INT >= 34 && context.getApplicationInfo().targetSdkVersion >= 34) {
+            context.registerReceiver(receiver, filter, exported ? Context.RECEIVER_EXPORTED : Context.RECEIVER_NOT_EXPORTED);
+        } else {
+            context.registerReceiver(receiver, filter);
         }
     }
 }


### PR DESCRIPTION
参考：
* https://github.com/facebook/react-native/issues/37769
* https://github.com/facebook/react-native/pull/38256/files

This PR should fix register receiver error when launching on Android 14.(#994 #992 #991 #969 #947)

周末，刚好睡不着，于是看看为什么662版本crash启动不起来。看日志是广播注册有问题，附参考链接，原因里面都讨论了不再赘述。