### PR TITLE
修复wifi连接vscode   布局分析问题 等。

### DIFF
--- a/app/src/main/java/org/autojs/autojs/Pref.java
+++ b/app/src/main/java/org/autojs/autojs/Pref.java
@@ -2,6 +2,7 @@ package org.autojs.autojs;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.os.Build;
 import android.os.Environment;
 import androidx.preference.PreferenceManager;
 import com.stardust.app.GlobalAppContext;
@@ -176,6 +177,9 @@ public class Pref {
     public static String getScriptDirPath() {
         String dir = def().getString(getString(R.string.key_script_dir_path),
                 getString(R.string.default_value_script_dir_path));
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            return new File( GlobalAppContext.get().getFilesDir(), dir).getPath();
+        }
         return new File(Environment.getExternalStorageDirectory(), dir).getPath();
     }
 

--- a/app/src/main/java/org/autojs/autojs/devplugin/Connection.kt
+++ b/app/src/main/java/org/autojs/autojs/devplugin/Connection.kt
@@ -2,7 +2,9 @@ package org.autojs.autojs.devplugin
 
 import android.os.Build
 import android.util.Log
+import com.google.gson.FieldNamingPolicy
 import com.google.gson.Gson
+import com.google.gson.GsonBuilder
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 import com.google.gson.JsonPrimitive
@@ -36,7 +38,9 @@ import org.autojs.autoxjs.BuildConfig
 import java.io.File
 import java.net.SocketTimeoutException
 
-private val gson get() = Gson()
+private val gson get() = GsonBuilder()
+    .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+    .create();
 private const val CLIENT_VERSION = 2
 private const val TAG = "DevPlugin"
 private const val TYPE_HELLO = "hello"

--- a/app/src/main/java/org/autojs/autojs/ui/floating/CircularMenu.kt
+++ b/app/src/main/java/org/autojs/autojs/ui/floating/CircularMenu.kt
@@ -19,6 +19,7 @@ import com.stardust.view.accessibility.NodeInfo
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.onFailure
 import kotlinx.coroutines.channels.onSuccess
+import kotlinx.coroutines.channels.trySendBlocking
 import org.autojs.autojs.Pref
 import org.autojs.autojs.autojs.AutoJs
 import org.autojs.autojs.autojs.record.GlobalActionRecorder
@@ -231,7 +232,7 @@ class CircularMenu(context: Context) : Recorder.OnStateChangedListener, CaptureA
     }
 
     override fun onCaptureAvailable(capture: NodeInfo) {
-        captureChannel.trySend(capture)
+        captureChannel.trySendBlocking(capture)
     }
 
     fun settings() {

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
     implementation(libs.ktor.serialization.kotlinx.json)
     implementation(libs.ktor.client.logging)
 
-    implementation(libs.logback.classic)
+    compileOnly(libs.logback.classic)
 
     implementation(libs.google.gson)
 


### PR DESCRIPTION
or its super classes (declaration of 'java.lang.Class' appears in /apex/com.android.art/javalib/core-oj.jar)
修复错误，日志无法正常使用android14

修复android14 中工程项目显示异常问题。

修复布局分析问题

wifi 链接vscode报错，原因是 转换的实体类上的注解不对，因此直接使用GsonBuilder() 进行属性填充。
