### PR TITLE
支持用autoxscript://sdcard/脚本/file.js方式调用脚本

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -321,7 +321,8 @@
 
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-
+                
+                <data android:scheme="autoxscript"/>
                 <data android:scheme="file" />
                 <data android:scheme="content" />
                 <data android:mimeType="application/x-javascript" />


### PR DESCRIPTION
autox本身支持file://sdcard/脚本/file.js方式调用脚本，只是file协议比较通用，会弹出选择使用那种查询打开的对话框，增加了一种专有协议名称。